### PR TITLE
docs: Update broken and redirected links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,39 @@
-# Personal web page
+# Petr Ruzicka's Personal Website (petr.ruzicka.dev)
+
+This repository contains the source code for Petr Ruzicka's personal website (petr.ruzicka.dev), built with Hugo and the Aerial theme. The website showcases his work as a DevOps specialist and SysAdmin, as well as his photography.
 
 [![Build Status](https://github.com/ruzickap/petr.ruzicka.dev/workflows/hugo-build/badge.svg)](https://github.com/ruzickap/petr.ruzicka.dev)
 
-## Installation
+## Live Site
+
+You can visit the live site at [https://petr.ruzicka.dev/](https://petr.ruzicka.dev/).
+
+## Getting Started
+
+To get a local copy up and running, follow these simple steps.
+
+### Prerequisites
+
+Make sure you have Git installed on your system.
+
+### Cloning
+
+1. Clone the repo:
+   ```bash
+   git clone --recurse-submodules https://github.com/ruzickap/petr.ruzicka.dev.git
+   ```
+2. Navigate to the project directory:
+   ```bash
+   cd petr.ruzicka.dev
+   ```
+
+## Theme
+
+This site uses the [Aerial](https://github.com/cewood/aerial) theme for Hugo.
+
+## Installing Hugo
+
+Hugo is required to build and run this website. You can install it as follows:
 
 ### Mac
 
@@ -10,18 +41,18 @@
 brew update && brew install hugo
 ```
 
-Just download binary from [https://github.com/spf13/hugo/releases](https://github.com/spf13/hugo/releases)
+Just download binary from [https://github.com/gohugoio/hugo/releases](https://github.com/gohugoio/hugo/releases)
 
-### Usage - look into [Quick Start](https://gohugo.io/overview/quickstart/)
+## Running Locally
 
-- Run local web server
+Once you have cloned the repository and installed Hugo, you can run the site locally.
 
-```bash
-hugo server --buildDrafts
-```
+- Run local web server:
+  ```bash
+  hugo server --buildDrafts
+  ```
 
-- Generate new version
-
-```bash
-hugo -d public
-```
+- Generate new version (for deployment):
+  ```bash
+  hugo -d public
+  ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Petr Ruzicka's Personal Website (petr.ruzicka.dev)
 
-This repository contains the source code for Petr Ruzicka's personal website (petr.ruzicka.dev), built with Hugo and the Aerial theme. The website showcases his work as a DevOps specialist and SysAdmin, as well as his photography.
+This repository contains the source code for Petr Ruzicka's personal website
+(petr.ruzicka.dev), built with Hugo and the Aerial theme. The website
+showcases his work as a DevOps specialist and SysAdmin, as well as his
+photography.
 
 [![Build Status](https://github.com/ruzickap/petr.ruzicka.dev/workflows/hugo-build/badge.svg)](https://github.com/ruzickap/petr.ruzicka.dev)
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,13 @@ Make sure you have Git installed on your system.
 ### Cloning
 
 1. Clone the repo:
+
    ```bash
    git clone --recurse-submodules https://github.com/ruzickap/petr.ruzicka.dev.git
    ```
+
 2. Navigate to the project directory:
+
    ```bash
    cd petr.ruzicka.dev
    ```
@@ -51,11 +54,14 @@ Just download binary from [https://github.com/gohugoio/hugo/releases](https://gi
 Once you have cloned the repository and installed Hugo, you can run the site locally.
 
 - Run local web server:
+
   ```bash
   hugo server --buildDrafts
   ```
 
 - Generate new version (for deployment):
+
   ```bash
   hugo -d public
   ```
+


### PR DESCRIPTION
- Corrected the Aerial theme URL to point to the actual submodule source (`https://github.com/cewood/aerial`).
- Updated the Hugo releases URL to the direct, non-redirecting link (`https://github.com/gohugoio/hugo/releases`).