### PR TITLE
fix: Pixabay URL format and update accepted status codes

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,1 +1,1 @@
-https://pixabay.com
+https://pixabay\.com

--- a/lychee.toml
+++ b/lychee.toml
@@ -18,7 +18,7 @@ max_concurrency = 128
 #############################  Requests  ############################
 
 # Comma-separated list of accepted status codes for valid links.
-accept = [999]
+accept = [429, 999]
 
 #############################  Exclusions  ##########################
 
@@ -31,8 +31,6 @@ exclude = [
   '\$',
   # Ignore all URLs which starts with 'file://'
   'file://',
-  # returns 429 when accessed from GitHub Action
-  'instagram\.com',
   # returns 403 when accessed from GitHub Action
   'stackexchange\.com',
   # returns 403 when accessed from GitHub Action


### PR DESCRIPTION
Update the Pixabay URL format to ensure proper matching and add the 429 status code to the list of accepted response codes for valid links.