### PR TITLE
fix: remove --root-dir from lychee remote URL check

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
-          args: --include-verbatim --no-progress ${{ steps.pages.outputs.base_url }} --root-dir "${PWD}"
+          args: --include-verbatim --no-progress ${{ steps.pages.outputs.base_url }}
 
       - name: Save lychee cache
         uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4


### PR DESCRIPTION
## Summary

- Remove `--root-dir "${PWD}"` from the lychee link checker args in the `links.yml` workflow
- The `--root-dir` flag is meant for local filesystem path resolution, but this workflow checks a **remote** URL (`https://petr.ruzicka.dev`)
- When lychee encounters absolute paths (e.g. `/apple-touch-icon.png`) in the remote HTML, `--root-dir` prepends the CI runner's filesystem path, producing mangled 404 URLs like `https://petr.ruzicka.dev/home/runner/work/petr.ruzicka.dev/petr.ruzicka.dev/apple-touch-icon.png`

Fixes 4 of the 5 errors in https://github.com/ruzickap/petr.ruzicka.dev/actions/runs/23396346940/job/68060215843 (the 5th is Unsplash returning 401 to automated requests).