### PR TITLE
fix: exclude unsplash.com from link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,2 +1,3 @@
 pixabay\.com
+unsplash\.com
 www\.instagram\.com


### PR DESCRIPTION
## Summary

- Add `unsplash\.com` to `.lycheeignore` to prevent link checker
  failures caused by Unsplash returning 401 Unauthorized for
  automated requests
- Consistent with existing exclusions for other bot-blocking sites
  (Pixabay, Instagram)