### PR TITLE
feat: add Bluesky social link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -20,6 +20,8 @@ socials:
     icon: "fab fa-instagram"
   - url: "https://mastodon.social/@petr_ruzicka"
     icon: "fab fa-mastodon"
+  - url: "https://bsky.app/profile/petrruzicka.bsky.social"
+    icon: "fab fa-bluesky"
   # Photography
   - url: "https://500px.com/petrruzicka"
     icon: "fab fa-500px"
@@ -58,6 +60,10 @@ links:
     icon: "fab fa-mastodon"
     title: "Mastodon"
     description: "Connect with me on Mastodon"
+  - href: "https://bsky.app/profile/petrruzicka.bsky.social"
+    icon: "fab fa-bluesky"
+    title: "Bluesky"
+    description: "Follow me on Bluesky"
   # Photography
   - href: "https://500px.com/petrruzicka"
     icon: "fab fa-500px"


### PR DESCRIPTION
## Summary

- Add Bluesky social link (petrruzicka.bsky.social) to both the
  icon-only `socials` section and the `links` card section
- Uses `fab fa-bluesky` icon from Font Awesome 7.0.1