### PR TITLE
fix: use glob patterns in gh-pages-build path filters

### DIFF
--- a/.github/workflows/gh-pages-build.yml
+++ b/.github/workflows/gh-pages-build.yml
@@ -13,12 +13,12 @@ on:
         default: false
   push:
     paths:
-      - content
-      - data
+      - content/**
+      - data/**
       - hugo.toml
-      - layouts
-      - static
-      - themes
+      - layouts/**
+      - static/**
+      - themes/**
 
 permissions: read-all
 


### PR DESCRIPTION
## Summary

- Add `/**` glob suffix to directory entries in `gh-pages-build`
  workflow path filters (`content`, `data`, `layouts`, `static`,
  `themes`)
- Bare directory names were treated as exact file matches, not
  directory prefixes, which prevented the workflow from triggering
  on pushes that modified files within those directories

Fixes the issue where merging PR #123 did not trigger the
`gh-pages-build` workflow despite changing `content/_index.md`.