### PR TITLE
chore: remove default languageCode from hugo config

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,4 @@
 baseURL = "https://petr.ruzicka.dev/"
-languageCode = "en-us"
 title = "Petr Ruzicka"
 theme = "LucentLink-Hugo"
 minVersion = "0.115.0"


### PR DESCRIPTION
## What

Removes the explicit `languageCode = "en-us"` setting from `hugo.toml`.

## Why

Hugo already defaults `languageCode` to `en-us`, so the explicit setting is
redundant. Dropping it keeps the config minimal without changing the rendered
output.